### PR TITLE
Avoid infinite errors loop with unavailable srcset

### DIFF
--- a/admin/jqadm/themes/custom.js
+++ b/admin/jqadm/themes/custom.js
@@ -690,6 +690,11 @@ Aimeos.CMSContent = {
 								srcset && model.addAttributes({ srcset })
 							}
 						});
+					},
+					onError() {
+						const fallback = this.model.getSrcResult({ fallback: 1 });
+						if (fallback) this.el.src = fallback;
+						if (fallback) this.el.removeAttribute('srcset');
 					}
 				}
 			});


### PR DESCRIPTION
GrapesJS updates the src attribute by default. 
![image](https://user-images.githubusercontent.com/25797598/143767150-3f9faca5-a8d7-4da4-b731-b6bde87aa852.png)
But if srcset exists and a request to it returns an error GrapesJS will update src endlessly.
Simple illustration:
![illustration](https://user-images.githubusercontent.com/25797598/143767370-288bf57a-5c2d-4325-9cb6-432343708a14.jpg)
