### PR TITLE
move the default data setup to the scope 'default' directory

### DIFF
--- a/setup/default/MShopAddTypeDataCms.php
+++ b/setup/default/MShopAddTypeDataCms.php
@@ -39,7 +39,7 @@ class MShopAddTypeDataCms extends MShopAddTypeData
 
 		$context->setEditor( 'ai-cms-grapesjs' );
 
-		$this->add( __DIR__ . $ds . 'default' . $ds . 'data' . $ds . 'type.php' );
+		$this->add( __DIR__ . $ds . 'data' . $ds .  'type.php' );
 
 		$context->setEditor( $editor );
 	}


### PR DESCRIPTION
If the User in this call  \Aimeos\Setup::use(new \Aimeos\Bootstrap())->context($context)->verbose()->up($code, '_new_template_');

Changing the second up() parameter to another one, in this case, _new_template_ for data setup, [ai-cms-grapesjs] was running also the _default_ data setup.

This PR solves the problem of loading the data depending on the data template specified by the user,  following the same logic as https://github.com/aimeos/aimeos-core/tree/master/setup



