### PR TITLE
Fix UTF-8 characters corrupted by loadHTML in CMS page rendering

### DIFF
--- a/src/Client/Html/Cms/Page/Cataloglist/Standard.php
+++ b/src/Client/Html/Cms/Page/Cataloglist/Standard.php
@@ -98,11 +98,13 @@ class Standard
 
 		libxml_use_internal_errors( true );
 
+        $encodingXml = '<?xml encoding="UTF-8"?>';
+
 		foreach( $view->pageContent as $content )
 		{
 			$dom = new \DOMDocument( '1.0', 'UTF-8' );
 			// @phpstan-ignore-next-line
-			$dom->loadHTML( $content, LIBXML_HTML_NOIMPLIED|LIBXML_HTML_NODEFDTD );
+			$dom->loadHTML( $encodingXml . $content, LIBXML_HTML_NOIMPLIED|LIBXML_HTML_NODEFDTD );
 			$nodes = $dom->getElementsByTagName( 'cataloglist' );
 
 			while( $nodes->length > 0 )
@@ -133,14 +135,14 @@ class Standard
 				}
 
 				$pdom = new \DOMDocument( '1.0', 'UTF-8' );
-				$pdom->loadHTML( $tview->render( $template ), LIBXML_HTML_NOIMPLIED|LIBXML_HTML_NODEFDTD );
+				$pdom->loadHTML( $encodingXml . $tview->render( $template ), LIBXML_HTML_NOIMPLIED|LIBXML_HTML_NODEFDTD );
 
 				// @phpstan-ignore-next-line
 				$pnode = $dom->importNode( $pdom->documentElement, true );
 				$node->parentNode->replaceChild( $pnode, $node );
 			}
 
-			$texts[] = $dom->saveHTML();
+			$texts[] = str_replace( $encodingXml, '', $dom->saveHTML() );
 		}
 
 		libxml_clear_errors();

--- a/src/Client/Html/Cms/Page/Cataloglist/Standard.php
+++ b/src/Client/Html/Cms/Page/Cataloglist/Standard.php
@@ -98,13 +98,9 @@ class Standard
 
 		libxml_use_internal_errors( true );
 
-        $encodingXml = '<?xml encoding="UTF-8"?>';
-
 		foreach( $view->pageContent as $content )
 		{
-			$dom = new \DOMDocument( '1.0', 'UTF-8' );
-			// @phpstan-ignore-next-line
-			$dom->loadHTML( $encodingXml . $content, LIBXML_HTML_NOIMPLIED|LIBXML_HTML_NODEFDTD );
+			$dom = $this->loadUTF8DOM( $content );
 			$nodes = $dom->getElementsByTagName( 'cataloglist' );
 
 			while( $nodes->length > 0 )
@@ -134,15 +130,14 @@ class Standard
 					$tview->itemsStockUrl = $this->getStockUrl( $tview, $articles );
 				}
 
-				$pdom = new \DOMDocument( '1.0', 'UTF-8' );
-				$pdom->loadHTML( $encodingXml . $tview->render( $template ), LIBXML_HTML_NOIMPLIED|LIBXML_HTML_NODEFDTD );
+				$pdom = $this->loadUTF8DOM( $tview->render( $template ) );
 
 				// @phpstan-ignore-next-line
 				$pnode = $dom->importNode( $pdom->documentElement, true );
 				$node->parentNode->replaceChild( $pnode, $node );
 			}
 
-			$texts[] = str_replace( $encodingXml, '', $dom->saveHTML() );
+			$texts[] = $dom->saveHTML();
 		}
 
 		libxml_clear_errors();
@@ -150,6 +145,32 @@ class Standard
 		$view->pageContent = $texts;
 
 		return parent::data( $view, $tags, $expire );
+	}
+
+	/**
+	 * Loads HTML into a DOMDocument with proper UTF-8 encoding handling.
+	 *
+	 * @param string $content HTML content to load
+	 * @return \DOMDocument Loaded DOM document
+	 */
+	private function loadUTF8DOM( string $content ) : \DOMDocument
+	{
+		$encodingXml = '<?xml encoding="UTF-8"?>';
+		$dom = new \DOMDocument( '1.0', 'UTF-8' );
+
+		// @phpstan-ignore-next-line
+		$dom->loadHTML( $encodingXml . $content, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+
+		foreach( $dom->childNodes as $item ) {
+			if( $item->nodeType == XML_PI_NODE ) {
+				$dom->removeChild( $item );
+				break;
+			}
+		}
+
+		$dom->encoding = 'UTF-8';
+
+		return $dom;
 	}
 
 


### PR DESCRIPTION
## Problem

Non-ASCII UTF-8 characters (e.g. `→`, `€`, CJK text) in CMS page content are corrupted on the frontend. Each byte of a multi-byte UTF-8 sequence is individually converted to an ISO-8859-1 HTML entity by `DOMDocument::saveHTML()`:

| Character | Expected  | Broken output       |
|-----------|-----------|---------------------|
| `→` (U+2192) | `&rarr;` or raw `→` | `&acirc;&#134;&#146;` |
| `€` (U+20AC) | `&euro;` or raw `€` | `&acirc;&#130;&not;`  |

The admin backend displays content correctly because it reads directly from the database. The frontend is affected because `Cataloglist\Standard::data()` passes every `pageContent` entry through `DOMDocument` — even when no `<cataloglist>`
elements are present.

<img width="612" height="196" alt="image" src="https://github.com/user-attachments/assets/75b3d296-5afe-406c-bd9a-8a54a0184588" />


## Root Cause

In `src/Client/Html/Cms/Page/Cataloglist/Standard.php`, `DOMDocument::loadHTML()` is called without a charset declaration:

```php
$dom->loadHTML( $content, LIBXML_HTML_NOIMPLIED|LIBXML_HTML_NODEFDTD );
```

Without an explicit encoding hint, libxml defaults to **ISO-8859-1** (per the HTML 4 spec). It interprets each byte of a UTF-8 multi-byte sequence as a separate Latin-1 character. When `saveHTML()` serializes the DOM back to a string, those individual bytes are emitted as HTML entities — producing mojibake.

The second `loadHTML()` call (for the product list template output at line 130) has the same issue and can corrupt currency symbols or localized product text.

## Fix

Prepend `<?xml encoding="UTF-8"?>` to the HTML input of both `loadHTML()` calls.
This XML declaration is recognized by libxml as an encoding hint, causing it to correctly parse the input as UTF-8. The processing instruction is stripped from the `saveHTML()` output so it does not leak into the rendered HTML.

```php
$encodingXml = '<?xml encoding="UTF-8"?>';

$dom->loadHTML( $encodingXml . $content, LIBXML_HTML_NOIMPLIED|LIBXML_HTML_NODEFDTD );
// ...
$pdom->loadHTML( $encodingXml . $tview->render( $template ), LIBXML_HTML_NOIMPLIED|LIBXML_HTML_NODEFDTD );
// ...
$texts[] = str_replace( $encodingXml, '', $dom->saveHTML() );
```

## Affected Scope

- Any CMS page whose text content contains non-ASCII characters (arrows,  currency symbols, accented letters, CJK characters, etc.)
- Any CMS page using `<cataloglist>` with product data containing non-ASCII text

## Notes

- The same pattern (`<?xml encoding="UTF-8"?>` prefix) is already used in `vendor/aimeos/sanitizer/src/Sane.php:65`, so this is consistent with existing Aimeos code.
- `LIBXML_HTML_NOIMPLIED` is preserved — no implied `<html>`/`<body>` wrappers are added.
- https://www.php.net/manual/zh/domdocument.loadhtml.php#95251